### PR TITLE
Make indicator position configurable

### DIFF
--- a/System_Monitor@bghome.gmail.com/prefs.js
+++ b/System_Monitor@bghome.gmail.com/prefs.js
@@ -220,6 +220,11 @@ const SystemMonitorPrefsWidget = new GObject.Class({
             upper: 10,
             step_increment: 1
         });
+        general_page.add_combo('Position on top bar.', PrefsKeys.POSITION, [
+          { "title": "Left side", "value": "left" },
+          { "title": "Center", "value": "center" },
+          { "title": "Right side", "value": "right" }
+        ], 'string');
         general_page.add_boolean('Enable CPU indicator.', PrefsKeys.CPU_METER);
         general_page.add_boolean('Enable memory indicator.', PrefsKeys.MEMORY_METER);
         general_page.add_boolean('Enable disk indicator.', PrefsKeys.STORAGE_METER);

--- a/System_Monitor@bghome.gmail.com/prefs_keys.js
+++ b/System_Monitor@bghome.gmail.com/prefs_keys.js
@@ -5,3 +5,4 @@ const STORAGE_METER = 'storage-meter';
 const NETWORK_METER = 'network-meter';
 const SWAP_METER = 'swap-meter';
 const LOAD_METER = 'load-meter';
+const POSITION = 'position';

--- a/System_Monitor@bghome.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/System_Monitor@bghome.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -36,5 +36,10 @@
         <summary>Enable system load indicator.</summary>
         <description>Turn on or off the system load indicator.</description>
     </key>
+    <key type="s" name="position">
+        <default>"center"</default>
+        <summary>Position on top bar.</summary>
+        <description>Controls the vertical alignment of the indicator widget on the top bar.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
There is a new configuration option called "Position on top bar."
available from the preferences window. It allows to set the indicator
position (Left side, Center, Right side) on the Top Bar of the Gnome Shell.

This solves issue https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues/11.