### PR TITLE
Fix name collision in status area ID

### DIFF
--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -44,7 +44,7 @@ const Menu = new Lang.Class({
         this._addIndicatorToTopBar(this._settings.get_string(PrefsKeys.POSITION));
     },
     _addIndicatorToTopBar: function(position) {
-        Panel.addToStatusArea('system-monitor', this, this._indicator_sort_order, position);
+        Panel.addToStatusArea(Me.metadata.uuid, this, this._indicator_sort_order, position);
         this._indicator_previous_position = position;
     },
     _moveIndicatorOnTopBar: function(position) {


### PR DESCRIPTION
When the extension registers the indicator widget with the Gnome Shell
top panel (aka. status area), it has to provide an ID (aka. role) which
must be unique across all extensions. It turned out that the current ID
"system-monitor" is used by other extension as well. This ID collision
causes all extensions sharing the same ID, except the first to fail to load.

This commit fixes that by using the extension's UUID which is unique by
definition.

Fixes issue https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues/32.