### PR TITLE
Fix listing mounted filesystems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+script:
+  - rake build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # System Monitor
 
+[![codebeat badge](https://codebeat.co/badges/7d1c7fdf-19b1-402a-b222-b2791e868e1d)](https://codebeat.co/projects/github-com-elvetemedve-gnome-shell-extension-system-monitor-master)
+[![Build Status](https://travis-ci.org/elvetemedve/gnome-shell-extension-system-monitor.svg?branch=master)](https://travis-ci.org/elvetemedve/gnome-shell-extension-system-monitor)
+
 ## Introduction
 
 ### What is System Monitor?

--- a/System_Monitor@bghome.gmail.com/meter.js
+++ b/System_Monitor@bghome.gmail.com/meter.js
@@ -301,7 +301,7 @@ MemoryMeter.prototype = new MeterSubject();
 
 const StorageMeter = function() {
 	this.observers = [];
-	let mount_entry = new RegExp('^\\S+\\s+(\\S+)\\s+(\\S+)');
+	let mount_entry_pattern = new RegExp('^\\S+\\s+(\\S+)\\s+(\\S+)');
 	let fs_types_to_measure = [
 		'btrfs', 'exfat', 'ext2', 'ext3', 'ext4', 'f2fs',
 	 	'hfs', 'jfs', 'nilfs2', 'ntfs', 'reiser4', 'reiserfs', 'vfat', 'xfs',
@@ -327,11 +327,12 @@ const StorageMeter = function() {
 			return new Promise((resolve, reject) => {
 				GLib.idle_add(GLib.PRIORITY_LOW, Lang.bind(this, function(contents) {
 					try {
-						let mount_list = contents.split("\n");
-						mount_list.splice(-2);	// remove the last two empty lines
+						let mount_list = contents.split("\n").filter(function(mount_entry) {
+                            return mount_entry.trim().length > 0;
+                        });
 						let directory_stats = [];
 						for (let i = 0; i < mount_list.length; i++) {
-							let [, mount_dir, fs_type] = mount_list[i].match(mount_entry);
+							let [, mount_dir, fs_type] = mount_list[i].match(mount_entry_pattern);
 							if (fs_types_to_measure.indexOf(fs_type) == -1) {
 								continue;
 							}


### PR DESCRIPTION
Currently the last two lines are removed from mount list, because it was
empty. However as kernel versions change, this changes as well. As a
result non-empty lines are removed, thus causing mount points not
showing up in the top mounted filesystems list.