### PR TITLE
Workaround for warning about Symbol.toPrimitive

### DIFF
--- a/System_Monitor@bghome.gmail.com/factory.js
+++ b/System_Monitor@bghome.gmail.com/factory.js
@@ -133,14 +133,15 @@ const FileFactory = (function() {
 				openedFiles[namespace] = {};
 			}
 
-			let file = openedFiles[namespace][filename];
+			let openedFilesInNs = openedFiles[namespace];
+			let file = openedFilesInNs[filename];
 
 			if (!!file) {
 				return file;
 			}
 
 			file = new FileModule.File(filename);
-			openedFiles[namespace][filename] = file;
+            openedFilesInNs[filename] = file;
 			return file;
 		},
 


### PR DESCRIPTION
This is a simple workaround for #39 as proposed in micheleg/dash-to-dock#586.

Note: I don't know why the original code causes these warnings at all.

Fixes #39.