### PR TITLE
Drop support of old Gnome versions

### DIFF
--- a/System_Monitor@bghome.gmail.com/metadata.json
+++ b/System_Monitor@bghome.gmail.com/metadata.json
@@ -1,9 +1,9 @@
 {
-	"shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26"],
+	"shell-version": ["3.26"],
 	"uuid": "System_Monitor@bghome.gmail.com",
 	"name": "System Monitor",
 	"description": "Display resource usage.\n\nLinux distribution specific installation instructions can be found in the wiki at https://github.com/elvetemedve/gnome-shell-extension-system-monitor/wiki/Installation.\n\nPlease report bugs here: https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues",
     "settings-schema": "org.gnome.shell.extensions.system-monitor",
 	"url": "https://github.com/elvetemedve/gnome-shell-extension-system-monitor",
-	"version": "11"
+	"version": "12"
 }


### PR DESCRIPTION
Gnome 3.26 complains about the current code is not ECMAScript 6 compatible. This has been fixed,
but old Gnome versions does not understand the new syntax.

This commit updates the metadata of the extension to drop support of all
Gnome versions starting from 3.24.