### PR TITLE
Feature/add show activity back

### DIFF
--- a/System_Monitor@bghome.gmail.com/extension.js
+++ b/System_Monitor@bghome.gmail.com/extension.js
@@ -33,6 +33,7 @@ const Timer = new Lang.Class({
         }
         if (this._change_event_id) {
             this._settings.disconnect(this._change_event_id);
+            this._change_event_id = null;
         }
     },
 

--- a/System_Monitor@bghome.gmail.com/factory.js
+++ b/System_Monitor@bghome.gmail.com/factory.js
@@ -54,8 +54,7 @@ IconFactory.prototype.concreteClass = IndicatorModule.Icon;
 // Create an indicator icon object, options will be passed to the real object's constructor.
 //
 // For working with themed icons see http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
-IconFactory.prototype.create = function(type, options) {
-
+IconFactory.prototype.create = function(type, options, can_show_activity) {
 	let default_options = {
 		style_class: 'system-status-icon system-monitor-icon',
 		reactive: true,
@@ -82,17 +81,14 @@ IconFactory.prototype.create = function(type, options) {
 		throw new RangeError('Unknown indicator type "' + type + '" given.');
 	}
 
-	IconFactory.prototype.concreteClass.initColorRange(
-		[
-			{ red:190, green: 190, blue: 190 },
-			{ red:255, green: 204, blue: 0 },
-			{ red:255, green: 0, blue: 0 }
-		]
-	);
+    let range = [
+        { red:190, green: 190, blue: 190 },
+        { red:255, green: 204, blue: 0 },
+        { red:255, green: 0, blue: 0 }
+    ];
+	let caution_class = 'indicator-caution';
 
-	IconFactory.prototype.concreteClass.initCautionClass('indicator-caution');
-
-	return new IconFactory.prototype.concreteClass(constructor_options);
+	return new IconFactory.prototype.concreteClass(constructor_options, range, caution_class, can_show_activity);
 };
 
 AbstractFactory.registerObject('icon', IconFactory);
@@ -167,7 +163,7 @@ AbstractFactory.registerObject('meter-area-widget', MeterAreaWidgetFactory);
 
 const MeterWidgetFactory = function() {};
 
-MeterWidgetFactory.prototype.create = function(type, options) {
+MeterWidgetFactory.prototype.create = function(type, options, icon) {
 	let title, meter_widget;
 	if (type == PrefsKeys.CPU_METER) {
 		title = 'CPU';
@@ -191,7 +187,7 @@ MeterWidgetFactory.prototype.create = function(type, options) {
 		throw new RangeError('Unknown meter type "' + type + '" given.');
 	}
 
-    meter_widget.addTitleItem(new Widget.ResourceTitleItem(title, AbstractFactory.create('icon', type, {icon_size: 32}), 'loading...'));
+    meter_widget.addTitleItem(new Widget.ResourceTitleItem(title, icon, 'loading...'));
     for (var i = 0; i < 3; i++) {
         meter_widget.addMenuItem(AbstractFactory.create('meter-widget-item', type, options));
     }

--- a/System_Monitor@bghome.gmail.com/factory.js
+++ b/System_Monitor@bghome.gmail.com/factory.js
@@ -142,8 +142,9 @@ const FileFactory = (function() {
 		},
 
 		this.destroy = function(namespace) {
-			for (let filename in openedFiles[namespace]) {
-                delete openedFiles[namespace][filename];
+            let files = openedFiles[namespace];
+			for (let filename in files) {
+                delete files[filename];
 			}
 		}
 	};

--- a/System_Monitor@bghome.gmail.com/meter.js
+++ b/System_Monitor@bghome.gmail.com/meter.js
@@ -156,7 +156,9 @@ MeterSubject.prototype.hasActivity = function() {
 	});
 };
 
-MeterSubject.prototype.destroy = function() {};
+MeterSubject.prototype.destroy = function() {
+	// FIXME cancel all pending Promises.
+};
 
 var CpuMeter = function(options) {
     if (options && options.activity_threshold) {

--- a/System_Monitor@bghome.gmail.com/meter.js
+++ b/System_Monitor@bghome.gmail.com/meter.js
@@ -7,10 +7,18 @@ const FactoryModule = Me.imports.factory;
 const Util = Me.imports.util;
 const Promise = Me.imports.helpers.promise.Promise;
 
-function MeterSubject() {
+function MeterSubject(options) {
 	this.observers = [];
 	this.previous_usage = 0;
 	this.usage = 0;
+    this.activity_threshold = 0;
+
+    this.setActivityThreshold = function(value) {
+        if (value < 0 || value > 100) {
+            throw `Activity threshold must be within range [0, 100], but got "${value}."`;
+        }
+        this.activity_threshold = value;
+    }
 
 	this.add = function(object) {
 		this.observers.push(object);
@@ -56,18 +64,21 @@ MeterSubject.prototype.removeObserver = function(observer) {
 
 MeterSubject.prototype.notifyAll = function() {
 	if (this.observers.length > 0) {
-		this.previous_usage = this.usage;
-
 		Promise.all([
 			this.calculateUsage(),
 			this.getProcesses(),
             this.getInterfaces(),
 			this.getSystemLoad(),
-			this.getDirectories(),
-			this.hasActivity()
+			this.getDirectories()
 		]).then(params => {
-			this.notify.apply(this, params);
-		});
+            return this.hasActivity().then(activity => {
+                params.push(activity);
+                return params;
+            });
+		}).then(params => {
+            this.notify.apply(this, params);
+            this.previous_usage = this.usage;
+        });
 	}
 };
 
@@ -141,13 +152,16 @@ MeterSubject.prototype.getDirectories = function() {
  */
 MeterSubject.prototype.hasActivity = function() {
 	return new Promise(resolve => {
-		resolve(this.previous_usage < this.usage);
+		resolve(this.usage - this.previous_usage >= this.activity_threshold);
 	});
 };
 
 MeterSubject.prototype.destroy = function() {};
 
-var CpuMeter = function() {
+var CpuMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
 	this.observers = [];
 	this._statistics = {
 		cpu: { user:0, nice:0, guest:0, guest_nice:0, system:0, irq: 0, softirq: 0, idle: 0, iowait: 0, steal: 0 },
@@ -193,7 +207,8 @@ var CpuMeter = function() {
 				periods[index] = times[index] - previous_times[index];
 			}
 
-			return usage_calculator(periods);
+            this.usage = usage_calculator(periods);
+			return this.usage;
 		});
 	};
 
@@ -227,7 +242,15 @@ var CpuMeter = function() {
 CpuMeter.prototype = new MeterSubject();
 
 
-var MemoryMeter = function(calculation_method) {
+var MemoryMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
+    if (options && options.calculation_method) {
+        var calculation_method = options.calculation_method;
+    } else {
+        throw 'MemoryMeter expects to get a calculation method.';
+    }
 	this.observers = [];
 	if (-1 == ['ram_only', 'all'].indexOf(calculation_method)) {
 			throw new RangeError('Unknown memory calculation method given: ' + calculation_method);
@@ -299,7 +322,10 @@ var MemoryMeter = function(calculation_method) {
 MemoryMeter.prototype = new MeterSubject();
 
 
-var StorageMeter = function() {
+var StorageMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
 	this.observers = [];
 	let mount_entry_pattern = new RegExp('^\\S+\\s+(\\S+)\\s+(\\S+)');
 	let fs_types_to_measure = [
@@ -356,12 +382,19 @@ var StorageMeter = function() {
 StorageMeter.prototype = new MeterSubject();
 
 
-var NetworkMeter = function(refresh_interval) {
+var NetworkMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
+    if (options && options.refresh_interval) {
+        this._refresh_interval = options.refresh_interval;
+    } else {
+        throw 'NetworkMeter expects to get a refresh interval.';
+    }
 	this.observers = [];
 	this._statistics = {};
 	this._bandwidths = {};
     this._speeds = [];
-    this._refresh_interval = refresh_interval;
 
 	this.loadData = function() {
 		return FactoryModule.AbstractFactory.create('file', this, '/sys/class/net').list().then(files => {
@@ -487,7 +520,10 @@ var NetworkMeter = function(refresh_interval) {
 NetworkMeter.prototype = new MeterSubject();
 
 
-var SwapMeter = function() {
+var SwapMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
 	this.observers = [];
 	let swap_utility = new Util.Swap;
 	let processes = new Util.Processes;
@@ -541,7 +577,10 @@ var SwapMeter = function() {
 SwapMeter.prototype = new MeterSubject();
 
 
-var SystemLoadMeter = function() {
+var SystemLoadMeter = function(options) {
+    if (options && options.activity_threshold) {
+        this.setActivityThreshold(options.activity_threshold);
+    }
 	this.observers = [];
 	this._number_of_cpu_cores = null;
 	let load = new GTop.glibtop_loadavg();

--- a/System_Monitor@bghome.gmail.com/prefs.js
+++ b/System_Monitor@bghome.gmail.com/prefs.js
@@ -244,6 +244,7 @@ const SystemMonitorPrefsWidget = new GObject.Class({
             { "title": "Horizontal", "value": "horizontal" },
             { "title": "Vertical", "value": "vertical" }
         ], 'string');
+        general_page.add_boolean('Show activity on top bar.', PrefsKeys.SHOW_ACTIVITY);
         general_page.add_boolean('Enable CPU indicator.', PrefsKeys.CPU_METER);
         general_page.add_boolean('Enable memory indicator.', PrefsKeys.MEMORY_METER);
         general_page.add_boolean('Enable disk indicator.', PrefsKeys.STORAGE_METER);

--- a/System_Monitor@bghome.gmail.com/prefs_keys.js
+++ b/System_Monitor@bghome.gmail.com/prefs_keys.js
@@ -8,3 +8,4 @@ var LOAD_METER = 'load-meter';
 var POSITION = 'position';
 var LAYOUT = 'layout';
 var MEMORY_CALCULATION_METHOD = 'memory-calculation-method';
+var SHOW_ACTIVITY = 'show-activity';

--- a/System_Monitor@bghome.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/System_Monitor@bghome.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -51,5 +51,10 @@
         <summary>Memory calculation method for process list sorting.</summary>
         <description>Controls which type of memory needs to be included when computing memory usage for a process.</description>
     </key>
+    <key type="b" name="show-activity">
+        <default>true</default>
+        <summary>Show activity on top bar.</summary>
+        <description>When the indicator value raised above the given treshold, then the indicator icon gets a circle transparent background until the next refresh.</description>
+    </key>
   </schema>
 </schemalist>

--- a/System_Monitor@bghome.gmail.com/stylesheet.css
+++ b/System_Monitor@bghome.gmail.com/stylesheet.css
@@ -11,18 +11,9 @@
 
 .right-label
 {
-	min-width: 3em;
 	text-align: right;
 }
 
-.item-label
-{
-	max-width: 12em;
-    min-width: 8em;
-}
-.item-label.interface-label {
-    min-width: 1em;
-}
 .bytes-text {
     min-width: 4em;
     text-align: right;

--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -192,7 +192,6 @@ var Menu = new Lang.Class({
         }
         this._widget_area_container.removeMeter(meter_widget);
         delete this._meter_widgets[type];
-        meter_widget.destroy();
     },
     destroy: function() {
         let meters = this._meters;

--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -178,6 +178,7 @@ var Menu = new Lang.Class({
         for (let index in this._event_handler_ids) {
             this._settings.disconnect(this._event_handler_ids[index]);
         }
+        this._event_handler_ids = [];
     },
     _createMeterWidget: function(type, icon) {
         let meter_widget = FactoryModule.AbstractFactory.create('meter-widget', type, icon);
@@ -190,8 +191,6 @@ var Menu = new Lang.Class({
         if (this._meters[type]) {
             this._meters[type].removeObserver(meter_widget);
         }
-        this._widget_area_container.removeMeter(meter_widget);
-        this._widget_area_container.destroy();
         delete this._meter_widgets[type];
     },
     destroy: function() {

--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -25,8 +25,8 @@ var Menu = new Lang.Class({
         this.available_meters = [PrefsKeys.CPU_METER, PrefsKeys.MEMORY_METER, PrefsKeys.STORAGE_METER, PrefsKeys.NETWORK_METER, PrefsKeys.SWAP_METER, PrefsKeys.LOAD_METER];
 
         this._widget_area_container = FactoryModule.AbstractFactory.create('meter-area-widget');
-        this._widget_area_container.vertical = this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical';
-        this.menu.box.add_child(this._widget_area_container);
+        this._widget_area_container.actor.vertical = this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical';
+        this.menu.addMenuItem(this._widget_area_container);
 
         this._initIconsAndWidgets();
 
@@ -145,7 +145,7 @@ var Menu = new Lang.Class({
     _addLayoutSettingChangedHandler: function() {
         let event_id = this._settings.connect('changed::' + PrefsKeys.LAYOUT, Lang.bind(this, function(settings, key) {
             let isVertical = 'vertical' === settings.get_string(key);
-            this._widget_area_container.vertical = isVertical;
+            this._widget_area_container.actor.vertical = isVertical;
         }));
         this._event_handler_ids.push(event_id);
     },
@@ -191,6 +191,7 @@ var Menu = new Lang.Class({
             this._meters[type].removeObserver(meter_widget);
         }
         this._widget_area_container.removeMeter(meter_widget);
+        this._widget_area_container.destroy();
         delete this._meter_widgets[type];
     },
     destroy: function() {

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -325,7 +325,7 @@ var ProcessItemsContainer = new Lang.Class({
     Extends: MeterContainer,
 
     update: function(state) {
-        MeterContainer.prototype.update.call(this, state);
+        this.parent(state);
 
         for (let i = 0; i < this._menu_items.length; i++) {
             if (i in state.processes) {
@@ -347,7 +347,7 @@ var SystemLoadItemsContainer = new Lang.Class({
     Extends: MeterContainer,
 
     update: function(state) {
-        MeterContainer.prototype.update.call(this, state);
+        this.parent(state);
 
         let load = state.system_load;
         this._menu_items[0].setLabel(load.load_average_1 + ' / ' + load.load_average_5 + ' / ' + load.load_average_15);
@@ -372,7 +372,7 @@ var DirectoriesContainer = new Lang.Class({
     },
 
     update: function(state) {
-        MeterContainer.prototype.update.call(this, state);
+        this.parent(state);
 
         for (let i = 0; i < this._menu_items.length; i++) {
             if (i in state.directories) {
@@ -399,7 +399,7 @@ var NetworkInterfaceItemsContainer = new Lang.Class({
     },
 
     update: function(state) {
-        MeterContainer.prototype.update.call(this, state);
+        this.parent(state);
 
         for (let i = 0; i < this._menu_items.length; i++) {
             if (i in state.interfaces) {

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -28,7 +28,7 @@ let BaseMenuItem = new Lang.Class({
         this.label = new St.Label({text: text, style_class: "item-label"});
         this.labelBin = new St.Bin({child: this.label});
         this.actor.add(this.labelBin);
-        this.connect('active-changed', Lang.bind(this, this._activeChanged));
+        this._change_event_id = this.connect('active-changed', Lang.bind(this, this._activeChanged));
 
         if (summary_text) {
             this.rightLabel = new St.Label({text: summary_text, style_class: "right-label"});
@@ -38,7 +38,7 @@ let BaseMenuItem = new Lang.Class({
 
         if (button_icon) {
             this.button = new St.Button();
-            this.button.connect('clicked', Lang.bind(this, function(actor, event) {
+            this.button._click_event_id = this.button.connect('clicked', Lang.bind(this, function(actor, event) {
                 button_callback.call(this.button, actor, event, this.getState());
             }));
             this.button_icon = new St.Icon({
@@ -52,9 +52,13 @@ let BaseMenuItem = new Lang.Class({
     },
 
     destroy: function() {
-        this.disconnect('active-changed');
-        if (this.button instanceof St.Button) {
-            this.button.disconnect('clicked');
+        if (this._change_event_id) {
+            this.disconnect(this._change_event_id);
+            this._change_event_id = null;
+        }
+        if (this.button instanceof St.Button && this.button._click_event_id) {
+            this.button.disconnect(this.button._click_event_id);
+            this.button._click_event_id = null;
         }
         this.parent();
     },

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -246,11 +246,6 @@ var InterfaceItem = new Lang.Class({
     },
 });
 
-const Separator = new Lang.Class({
-    Name: "Separator",
-    Extends: PopupMenu.PopupSeparatorMenuItem
-});
-
 var MeterAreaContainer = new Lang.Class({
     Name: "MeterAreaContainer",
     Extends: St.BoxLayout,

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -248,26 +248,23 @@ var InterfaceItem = new Lang.Class({
 
 var MeterAreaContainer = new Lang.Class({
     Name: "MeterAreaContainer",
-    Extends: St.BoxLayout,
+    Extends: PopupMenu.PopupBaseMenuItem,
 
-    _init: function() {
-        this.parent({"accessible-name": 'meterArea', "vertical": false});
-    },
     addMeter: function(meter, position) {
         if (!meter instanceof MeterContainer) {
             throw new TypeError("First argument of addMeter() method must be instance of MeterContainer.");
         }
         if (position == undefined) {
-            this.add_actor(meter);
+            this.actor.add_actor(meter);
         } else {
-            this.insert_child_at_index(meter, position);
+            this.actor.insert_child_at_index(meter, position);
         }
     },
     removeMeter: function(meter) {
         if (!meter instanceof MeterContainer) {
             throw new TypeError("First argument of removeMeter() method must be instance of MeterContainer.");
         }
-        this.remove_actor(meter);
+        this.actor.remove_actor(meter);
     }
 });
 


### PR DESCRIPTION
Changes

- Add back the show activity feature. This highlights the symbolic icon of a resource when it's usage has increased. This feature can be disabled by opening the extension settings window and switch off the option "Show activity on top bar.".
- Fix most of the Javascript warnings generated by free up objects from `destroy()` functions.