### PR TITLE
Fix the this.parent method call in View class

### DIFF
--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -204,7 +204,7 @@ class Menu extends PanelMenu.Button {
         }
 
         this._removeAllSettingChangedHandlers();
-        this.parent();
+        super.destroy();
     }
     updateUi() {
         let meters = this._meters;


### PR DESCRIPTION
Changelog

- The `this.parent()` method call is no longer valid in ES6. (This fix should have gone into the previous PR.)