### PR TITLE
Use MemAvailable for memory

### DIFF
--- a/System_Monitor@bghome.gmail.com/meter.js
+++ b/System_Monitor@bghome.gmail.com/meter.js
@@ -264,7 +264,7 @@ var MemoryMeter = function(options) {
 	this.loadData = function() {
 		return FactoryModule.AbstractFactory.create('file', this, '/proc/meminfo').read().then(contents => {
 			let statistics = {};
-			let columns = ['memtotal','memfree','buffers','cached'];
+			let columns = ["memtotal", "memavailable"];
 
 			for (let index in columns) {
 				statistics[columns[index]] = parseInt(contents.match(new RegExp(columns[index] + '.*?(\\d+)', 'i')).pop());
@@ -275,7 +275,7 @@ var MemoryMeter = function(options) {
 
 	this.calculateUsage = function() {
 		return this.loadData().then(stat => {
-			let used = stat.memtotal - stat.memfree - stat.buffers - stat.cached;
+			let used = stat.memtotal - stat.memavailable;
 			this.usage = used / stat.memtotal * 100;
 			return this.usage;
 		});


### PR DESCRIPTION
Closes https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues/77

I changed used memory calculation more pessimistic by using `MemAvailable`. Why I think it is better.

**Reason 1:** `MemAvailable` is “an estimate of how much memory is available for starting new applications, without swapping”. I think it is better metric.

**Reason 2:** `MemAvailable` was added to `/proc/meminfo` because using `MemFree` and `Cached` is not accurate. Quote from [the commit to Linux kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773):

> Many load balancing and workload placing programs check /proc/meminfo to estimate how much free memory is available.  They generally do this by adding up "free" and "cached", which was fine ten years ago, but is pretty much guaranteed to be wrong today.
>
> It is wrong because Cached includes memory that is not freeable as page cache, for example shared memory segments, tmpfs, and ramfs, and it does not include reclaimable slab memory, which can take up a large fraction of system memory on mostly idle systems with lots of files.

**Reason 3:** I tested this patch and now value is exactly what GNOME System Monitor is showing.