### PR TITLE
Update extension for Gnome Shell 43 support

### DIFF
--- a/System_Monitor@bghome.gmail.com/metadata.json
+++ b/System_Monitor@bghome.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.32", "3.34", "3.38", "40.0", "41", "42"],
+	"shell-version": ["3.32", "3.34", "3.38", "40.0", "41", "42", "43"],
 	"uuid": "System_Monitor@bghome.gmail.com",
 	"name": "System Monitor",
 	"description": "Display resource usage.\n\nLinux distribution specific installation instructions can be found in the wiki at https://github.com/elvetemedve/gnome-shell-extension-system-monitor/wiki/Installation.\n\nPlease report bugs here: https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues",


### PR DESCRIPTION
Updating extension for Gnome Shell 43.  All credits go to [farlydetrias2022](https://github.com/farlydetrias2022)