### PR TITLE
Set max width for MeterContainer labels

### DIFF
--- a/System_Monitor@bghome.gmail.com/stylesheet.css
+++ b/System_Monitor@bghome.gmail.com/stylesheet.css
@@ -26,3 +26,7 @@
 .meter-area-container {
     background-color: inherit;
 }
+
+.item-label {
+    max-width: 16em;
+}


### PR DESCRIPTION
When an item text is too long the panel is expanded to stretch beyond the visible screen.
Setting a max width helps to avoid some edge cases.