### PR TITLE
Update metadata.json for Gnome 49 support

### DIFF
--- a/System_Monitor@bghome.gmail.com/metadata.json
+++ b/System_Monitor@bghome.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["45","46","47","48"],
+	"shell-version": ["45","46","47","48","49"],
 	"uuid": "System_Monitor@bghome.gmail.com",
 	"name": "System Monitor",
 	"description": "Display resource usage.\n\nLinux distribution specific installation instructions can be found in the wiki at https://github.com/elvetemedve/gnome-shell-extension-system-monitor/wiki/Installation.\n\nPlease report bugs here: https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues",


### PR DESCRIPTION
Works when updating manually as well.