### PR TITLE
fix(widget): constrain panel size during size negotiation to prevent overflow

### DIFF
--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -317,29 +317,46 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
 
         this._scrollView.set_child(this._contentBox);
         this.actor.add_child(this._scrollView);
-
-        this._mappedId = this.actor.connect('notify::mapped', () => {
-            if (this.actor.mapped) {
-                this._updateScrollViewSize();
-            }
-        });
     }
 
-    _updateScrollViewSize() {
-        let [x, y] = this.actor.get_transformed_position();
-        let monitorIndex = Main.layoutManager.findIndexForLocation(x, y);
-        if (monitorIndex < 0) {
-            monitorIndex = Main.layoutManager.primaryIndex;
+    _getMaxDimensions() {
+        let monitorIndex = Main.layoutManager.primaryIndex;
+
+        // Try to get the monitor where the actor is located
+        if (this.actor.mapped) {
+            let [x, y] = this.actor.get_transformed_position();
+            let idx = Main.layoutManager.findIndexForLocation(x, y);
+            if (idx >= 0) {
+                monitorIndex = idx;
+            }
         }
 
         let workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
 
-        let maxWidth = Math.floor(workArea.width * 0.9);
-        let maxHeight = Math.floor(workArea.height * 0.75);
+        return {
+            maxWidth: Math.floor(workArea.width * 0.9),
+            maxHeight: Math.floor(workArea.height * 0.75)
+        };
+    }
 
-        this._scrollView.set_style(
-            `max-width: ${maxWidth}px; max-height: ${maxHeight}px; min-width: 200px;`
-        );
+    vfunc_get_preferred_width(forHeight) {
+        let [minWidth, natWidth] = super.vfunc_get_preferred_width(forHeight);
+        let { maxWidth } = this._getMaxDimensions();
+
+        return [
+            Math.min(minWidth, maxWidth),
+            Math.min(natWidth, maxWidth)
+        ];
+    }
+
+    vfunc_get_preferred_height(forWidth) {
+        let [minHeight, natHeight] = super.vfunc_get_preferred_height(forWidth);
+        let { maxHeight } = this._getMaxDimensions();
+
+        return [
+            Math.min(minHeight, maxHeight),
+            Math.min(natHeight, maxHeight)
+        ];
     }
 
     addMeter(meter, position) {
@@ -352,14 +369,6 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
 
     removeMeter(meter) {
         this._contentBox.remove_child(meter);
-    }
-
-    destroy() {
-        if (this._mappedId) {
-            this.actor.disconnect(this._mappedId);
-            this._mappedId = null;
-        }
-        super.destroy();
     }
 });
 


### PR DESCRIPTION
A screenshotra nézve még ezt mondta:

Probléma: A CSS max-width stílus az allocation phase-ben érvényesül, de a popup menu pozicionálása a size request phase-ben történik (előbb). Így a popup a korlátozatlan méret alapján pozicionálta magát.

Megoldás: vfunc_get_preferred_width() és vfunc_get_preferred_height() override-ok, amik a size negotiation fázisban adják vissza a korlátozott értékeket. Így a popup menu már a helyes mérettel számol pozicionáláskor.

Változtatások:
- Eltávolítva: notify::mapped signal, _updateScrollViewSize(), destroy()
- Hozzáadva: _getMaxDimensions(), vfunc_get_preferred_width(), vfunc_get_preferred_height()

Ez a Clutter/GObject-natív módja a méretkorlátozásnak - nem CSS stílus, hanem a layout rendszer szintjén

--

Még egy próbát megér. 🙃