### PR TITLE
Update metadata.json for Gnome 50 support

### DIFF
--- a/System_Monitor@bghome.gmail.com/metadata.json
+++ b/System_Monitor@bghome.gmail.com/metadata.json
@@ -1,10 +1,10 @@
 {
-	"shell-version": ["45","46","47","48","49"],
+	"shell-version": ["45","46","47","48","49","50"],
 	"uuid": "System_Monitor@bghome.gmail.com",
 	"name": "System Monitor",
 	"description": "Display resource usage.\n\nLinux distribution specific installation instructions can be found in the wiki at https://github.com/elvetemedve/gnome-shell-extension-system-monitor/wiki/Installation.\n\nPlease report bugs here: https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues",
 	"settings-schema": "org.gnome.shell.extensions.system-monitor",
 	"gettext-domain": "System_Monitor@bghome.gmail.com",
 	"url": "https://github.com/elvetemedve/gnome-shell-extension-system-monitor",
-	"version": "40"
+	"version": "41"
 }


### PR DESCRIPTION
Closes #104 (Gnome 48 and 49 support was already added before)