### PR TITLE
Gracefully handle unsupported network interfaces

### DIFF
--- a/System_Monitor@bghome.gmail.com/meter.js
+++ b/System_Monitor@bghome.gmail.com/meter.js
@@ -446,11 +446,15 @@ export const NetworkMeter = function(options) {
 						});
 					}).catch(e => {
 						console.error('Network Meter load data failed: ' + e);
+						return {};
 					});
 				}
 			};
 			for (let device_name of files) {
-				let promise = FactoryModule.AbstractFactory.create('file', this, '/sys/class/net/' + device_name + '/type').read().then(new callback(device_name));
+				let promise = FactoryModule.AbstractFactory.create('file', this, '/sys/class/net/' + device_name + '/type')
+					.read()
+					.then(new callback(device_name))
+					.catch(() => ({})); // non-interface entry (e.g. bonding_masters): skip silently
 				device_names.push(device_name);
 				promises.push(promise);
 			}


### PR DESCRIPTION
Current code assumed that all network interfaces appear as directories under /sys/class/net/. However there are exception when a special file is created instead.

For example `bonding_masters` that read rejects with `Gio.IOErrorEnum: ... /sys/class/net/bonding_masters/type: Not a directory`.

This change handles these errors silently. So the interface is skipped and no log record is created.

Adding support for special network interfaces is out of scope for now.

This resolves issue https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues/109.