### PR TITLE
Feature/add scrollbars to dropdown panel

### DIFF
--- a/System_Monitor@bghome.gmail.com/stylesheet.css
+++ b/System_Monitor@bghome.gmail.com/stylesheet.css
@@ -27,6 +27,10 @@
     background-color: inherit;
 }
 
+.meter-area-scrollview {
+    background-color: inherit;
+}
+
 .item-label {
     max-width: 16em;
 }

--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -28,7 +28,7 @@ class Menu extends PanelMenu.Button {
         this._indicator_sort_order = 1;
         this.available_meters = [PrefsKeys.CPU_METER, PrefsKeys.MEMORY_METER, PrefsKeys.STORAGE_METER, PrefsKeys.NETWORK_METER, PrefsKeys.SWAP_METER, PrefsKeys.LOAD_METER];
         this._widget_area_container = FactoryModule.AbstractFactory.create('meter-area-widget');
-        this._widget_area_container.setOrientation(this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical' ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL);
+        this._widget_area_container.setOrientation(this._isVerticalLayout() ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL);
         this.menu.addMenuItem(this._widget_area_container);
         // The popup's actual on-screen position/size is only known once Clutter
         // has run a real layout pass - get_preferred_width() queried synchronously
@@ -39,6 +39,11 @@ class Menu extends PanelMenu.Button {
         // boxpointer arrow/border/padding chrome on top of our content) still
         // doesn't fit. Guarded so our own corrective resize - which triggers
         // another allocation - doesn't re-trigger itself.
+        //
+        // Which axis is capped depends on the layout setting: horizontal
+        // layout lays meters out in columns that can overflow the work area's
+        // width, vertical layout stacks them in rows that can instead overflow
+        // its height.
         this.menu.actor.connect('notify::allocation', () => {
             if (!this._pending_overflow_check) {
                 return;
@@ -49,9 +54,16 @@ class Menu extends PanelMenu.Button {
                 return;
             }
             let box = this.menu.actor.get_allocation_box();
-            let overflow = Math.max(work_area.x - box.x1, box.x2 - (work_area.x + work_area.width), 0);
-            if (overflow > 0) {
-                this._widget_area_container.setMaxWidth(this._widget_area_container.getWidth() - overflow);
+            if (this._isVerticalLayout()) {
+                let overflow = Math.max(work_area.y - box.y1, box.y2 - (work_area.y + work_area.height), 0);
+                if (overflow > 0) {
+                    this._widget_area_container.setMaxHeight(this._widget_area_container.getHeight() - overflow);
+                }
+            } else {
+                let overflow = Math.max(work_area.x - box.x1, box.x2 - (work_area.x + work_area.width), 0);
+                if (overflow > 0) {
+                    this._widget_area_container.setMaxWidth(this._widget_area_container.getWidth() - overflow);
+                }
             }
         });
         this._open_state_change_id = this.menu.connect('open-state-changed', (menu, is_open) => {
@@ -60,7 +72,11 @@ class Menu extends PanelMenu.Button {
                 let work_area = Main.layoutManager.getWorkAreaForMonitor(monitor_index);
                 this._open_work_area = work_area;
                 this._pending_overflow_check = true;
-                this._widget_area_container.setMaxWidth(work_area.width);
+                if (this._isVerticalLayout()) {
+                    this._widget_area_container.setMaxHeight(work_area.height);
+                } else {
+                    this._widget_area_container.setMaxWidth(work_area.width);
+                }
             }
             for (let type in this._meter_widgets) {
                 if (is_open) {
@@ -191,6 +207,9 @@ class Menu extends PanelMenu.Button {
             that._widget_area_container.setOrientation(orientation);
         });
         this._event_handler_ids.push(event_id);
+    }
+    _isVerticalLayout() {
+        return this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical';
     }
     _addMemoryCalculationSettingChangedHandler() {
         let that = this;

--- a/System_Monitor@bghome.gmail.com/view.js
+++ b/System_Monitor@bghome.gmail.com/view.js
@@ -5,7 +5,7 @@ import GObject from 'gi://GObject';
 import St from 'gi://St';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-import {panel as Panel} from 'resource:///org/gnome/shell/ui/main.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
 import * as FactoryModule from './factory.js';
@@ -28,9 +28,40 @@ class Menu extends PanelMenu.Button {
         this._indicator_sort_order = 1;
         this.available_meters = [PrefsKeys.CPU_METER, PrefsKeys.MEMORY_METER, PrefsKeys.STORAGE_METER, PrefsKeys.NETWORK_METER, PrefsKeys.SWAP_METER, PrefsKeys.LOAD_METER];
         this._widget_area_container = FactoryModule.AbstractFactory.create('meter-area-widget');
-        this._widget_area_container.actor.orientation = this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical' ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL;
+        this._widget_area_container.setOrientation(this._settings.get_string(PrefsKeys.LAYOUT) === 'vertical' ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL);
         this.menu.addMenuItem(this._widget_area_container);
+        // The popup's actual on-screen position/size is only known once Clutter
+        // has run a real layout pass - get_preferred_width() queried synchronously
+        // right after we resize a descendant returns a stale cached value, not
+        // the post-resize size, so we can't predict the final geometry upfront.
+        // Instead, size for the work area optimistically, then correct after
+        // the fact against the real allocation if the popup (which adds its own
+        // boxpointer arrow/border/padding chrome on top of our content) still
+        // doesn't fit. Guarded so our own corrective resize - which triggers
+        // another allocation - doesn't re-trigger itself.
+        this.menu.actor.connect('notify::allocation', () => {
+            if (!this._pending_overflow_check) {
+                return;
+            }
+            this._pending_overflow_check = false;
+            let work_area = this._open_work_area;
+            if (!work_area) {
+                return;
+            }
+            let box = this.menu.actor.get_allocation_box();
+            let overflow = Math.max(work_area.x - box.x1, box.x2 - (work_area.x + work_area.width), 0);
+            if (overflow > 0) {
+                this._widget_area_container.setMaxWidth(this._widget_area_container.getWidth() - overflow);
+            }
+        });
         this._open_state_change_id = this.menu.connect('open-state-changed', (menu, is_open) => {
+            if (is_open) {
+                let monitor_index = Main.layoutManager.findIndexForActor(this);
+                let work_area = Main.layoutManager.getWorkAreaForMonitor(monitor_index);
+                this._open_work_area = work_area;
+                this._pending_overflow_check = true;
+                this._widget_area_container.setMaxWidth(work_area.width);
+            }
             for (let type in this._meter_widgets) {
                 if (is_open) {
                     this._meter_widgets[type].freeze();
@@ -59,20 +90,20 @@ class Menu extends PanelMenu.Button {
         }
     }
     _addIndicatorToTopBar(position, uuid) {
-        Panel.addToStatusArea(uuid, this, this._indicator_sort_order, position);
+        Main.panel.addToStatusArea(uuid, this, this._indicator_sort_order, position);
         this._indicator_previous_position = position;
     }
     _moveIndicatorOnTopBar(position) {
         // Gnome does not provide a method to remove indicator (opposite to addToStatusArea() method), so this is a workaround.
         switch (this._indicator_previous_position) {
             case 'left':
-                Panel._leftBox.remove_actor(this.container);
+                Main.panel._leftBox.remove_actor(this.container);
                 break;
             case 'center':
-                Panel._centerBox.remove_actor(this.container);
+                Main.panel._centerBox.remove_actor(this.container);
                 break;
             case 'right':
-                Panel._rightBox.remove_actor(this.container);
+                Main.panel._rightBox.remove_actor(this.container);
                 break;
             default:
                 throw new Error('Unknown position given: ' + this._indicator_previous_position);
@@ -80,13 +111,13 @@ class Menu extends PanelMenu.Button {
 
         switch (position) {
             case 'left':
-                Panel._leftBox.insert_child_at_index(this.container, this._indicator_sort_order);
+                Main.panel._leftBox.insert_child_at_index(this.container, this._indicator_sort_order);
                 break;
             case 'center':
-                Panel._centerBox.insert_child_at_index(this.container, this._indicator_sort_order);
+                Main.panel._centerBox.insert_child_at_index(this.container, this._indicator_sort_order);
                 break;
             case 'right':
-                Panel._rightBox.insert_child_at_index(this.container, this._indicator_sort_order);
+                Main.panel._rightBox.insert_child_at_index(this.container, this._indicator_sort_order);
                 break;
             default:
                 throw new Error('Unknown position given: ' + position);
@@ -157,7 +188,7 @@ class Menu extends PanelMenu.Button {
         let that = this;
         let event_id = this._settings.connect('changed::' + PrefsKeys.LAYOUT, function(settings, key) {
             let orientation = 'vertical' === settings.get_string(key) ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL;
-            that._widget_area_container.actor.orientation = orientation;
+            that._widget_area_container.setOrientation(orientation);
         });
         this._event_handler_ids.push(event_id);
     }

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -308,14 +308,10 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
         } else {
             this._scroll_view.add_actor(this._meter_box);
         }
-        // vscrollbar is always off; hscrollbar policy is driven explicitly by
-        // setMaxWidth() below rather than left on AUTOMATIC (see there for why).
-        if (this._scroll_view.set_policy) {
-            this._scroll_view.set_policy(St.PolicyType.NEVER, St.PolicyType.NEVER);
-        } else {
-            this._scroll_view.hscrollbar_policy = St.PolicyType.NEVER;
-            this._scroll_view.vscrollbar_policy = St.PolicyType.NEVER;
-        }
+        // Both scrollbars start off; policy is driven explicitly per axis by
+        // setMaxWidth()/setMaxHeight() below rather than left on AUTOMATIC
+        // (see there for why).
+        this._setScrollbarPolicy(St.PolicyType.NEVER, St.PolicyType.NEVER);
         this.actor.add_child(this._scroll_view);
     }
     setOrientation(orientation) {
@@ -323,6 +319,9 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
     }
     getWidth() {
         return this._scroll_view.width;
+    }
+    getHeight() {
+        return this._scroll_view.height;
     }
     setMaxWidth(px) {
         // Always set an explicit width rather than relying on St.ScrollView's own
@@ -345,8 +344,13 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
         let [, natural_width] = this._meter_box.get_preferred_width(-1);
         let needs_scroll = px && natural_width > px;
         this._scroll_view.width = needs_scroll ? px : natural_width;
+        // Reset the other axis to natural sizing: only one of setMaxWidth()/
+        // setMaxHeight() is in effect at a time (driven by the layout
+        // orientation), so a cap left over from the other one - e.g. from
+        // before a layout setting change - must not linger here.
+        this._scroll_view.height = -1;
 
-        // Drive the hscrollbar policy from our own overflow check instead of
+        // Drive the scrollbar policy from our own overflow check instead of
         // leaving it on AUTOMATIC: St.ScrollView's own "hide if nothing to
         // scroll" logic doesn't reliably re-run after we force this width -
         // measured directly, the scrollbar actor stayed visible even once the
@@ -354,10 +358,28 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
         // with nothing left to scroll). We already know from natural_width vs.
         // px whether scrolling is actually needed, so use that instead of
         // relying on St to notice on its own.
+        this._setScrollbarPolicy(needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER, St.PolicyType.NEVER);
+    }
+    setMaxHeight(px) {
+        // Vertical counterpart of setMaxWidth() above, for when the meters are
+        // stacked in rows (vertical layout) instead of columns (horizontal
+        // layout): capped dimension is height, and it's the vscrollbar that's
+        // driven explicitly. See setMaxWidth() for the reasoning that applies
+        // equally here (hard actor size vs. natural-width-set/CSS, and driving
+        // the scrollbar policy ourselves instead of trusting AUTOMATIC).
+        let [, natural_height] = this._meter_box.get_preferred_height(-1);
+        let needs_scroll = px && natural_height > px;
+        this._scroll_view.height = needs_scroll ? px : natural_height;
+        this._scroll_view.width = -1;
+
+        this._setScrollbarPolicy(St.PolicyType.NEVER, needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER);
+    }
+    _setScrollbarPolicy(hscrollbar_policy, vscrollbar_policy) {
         if (this._scroll_view.set_policy) {
-            this._scroll_view.set_policy(needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER, St.PolicyType.NEVER);
+            this._scroll_view.set_policy(hscrollbar_policy, vscrollbar_policy);
         } else {
-            this._scroll_view.hscrollbar_policy = needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
+            this._scroll_view.hscrollbar_policy = hscrollbar_policy;
+            this._scroll_view.vscrollbar_policy = vscrollbar_policy;
         }
     }
     addMeter(meter, position) {

--- a/System_Monitor@bghome.gmail.com/widget.js
+++ b/System_Monitor@bghome.gmail.com/widget.js
@@ -298,22 +298,83 @@ class MeterAreaContainer extends PopupMenu.PopupBaseMenuItem {
         super({
             style_class: "meter-area-container"
         });
+        this._meter_box = new St.BoxLayout();
+        this._scroll_view = new St.ScrollView({
+            style_class: "meter-area-scrollview"
+        });
+        // GNOME 45 uses add_actor(); GNOME 46+ replaced it with set_child().
+        if (this._scroll_view.set_child) {
+            this._scroll_view.set_child(this._meter_box);
+        } else {
+            this._scroll_view.add_actor(this._meter_box);
+        }
+        // vscrollbar is always off; hscrollbar policy is driven explicitly by
+        // setMaxWidth() below rather than left on AUTOMATIC (see there for why).
+        if (this._scroll_view.set_policy) {
+            this._scroll_view.set_policy(St.PolicyType.NEVER, St.PolicyType.NEVER);
+        } else {
+            this._scroll_view.hscrollbar_policy = St.PolicyType.NEVER;
+            this._scroll_view.vscrollbar_policy = St.PolicyType.NEVER;
+        }
+        this.actor.add_child(this._scroll_view);
+    }
+    setOrientation(orientation) {
+        this._meter_box.orientation = orientation;
+    }
+    getWidth() {
+        return this._scroll_view.width;
+    }
+    setMaxWidth(px) {
+        // Always set an explicit width rather than relying on St.ScrollView's own
+        // unconstrained preferred size, which is not guaranteed to equal the
+        // content's natural width (scroll views commonly default to a small
+        // baseline size instead of sizing to their child, requiring an explicit
+        // opt-in to do otherwise). Size to the content's own natural width when
+        // it fits - so the viewport matches the content exactly and no scrollbar
+        // appears - or to the clamped budget when it doesn't - so the viewport is
+        // smaller than the content and the columns stay full width and scrollable
+        // instead of being shrunk to fit.
+        //
+        // This must be a hard actor width, not a CSS max-width or St's
+        // natural-width-set: St.ScrollView implements its own get_preferred_width
+        // (to account for the child plus scrollbar), so it does not consult
+        // St.Widget's generic natural-width override, and a CSS max-width here
+        // would also cap the columns' own natural width instead of letting them
+        // overflow into the scrollable area. A hard Clutter width is enforced by
+        // ClutterActor before any subclass vfunc runs, so it always applies.
+        let [, natural_width] = this._meter_box.get_preferred_width(-1);
+        let needs_scroll = px && natural_width > px;
+        this._scroll_view.width = needs_scroll ? px : natural_width;
+
+        // Drive the hscrollbar policy from our own overflow check instead of
+        // leaving it on AUTOMATIC: St.ScrollView's own "hide if nothing to
+        // scroll" logic doesn't reliably re-run after we force this width -
+        // measured directly, the scrollbar actor stayed visible even once the
+        // adjustment's page-size caught up to equal its upper bound (i.e. even
+        // with nothing left to scroll). We already know from natural_width vs.
+        // px whether scrolling is actually needed, so use that instead of
+        // relying on St to notice on its own.
+        if (this._scroll_view.set_policy) {
+            this._scroll_view.set_policy(needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER, St.PolicyType.NEVER);
+        } else {
+            this._scroll_view.hscrollbar_policy = needs_scroll ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
+        }
     }
     addMeter(meter, position) {
         if (!meter instanceof MeterContainer) {
             throw new TypeError("First argument of addMeter() method must be instance of MeterContainer.");
         }
         if (position == undefined) {
-            this.actor.add_child(meter);
+            this._meter_box.add_child(meter);
         } else {
-            this.actor.insert_child_at_index(meter, position);
+            this._meter_box.insert_child_at_index(meter, position);
         }
     }
     removeMeter(meter) {
         if (!meter instanceof MeterContainer) {
             throw new TypeError("First argument of removeMeter() method must be instance of MeterContainer.");
         }
-        this.actor.remove_child(meter);
+        this._meter_box.remove_child(meter);
     }
 });
 
@@ -345,12 +406,20 @@ class MeterContainer extends St.BoxLayout {
         this._menu_items.length = 0;
     }
     freeze() {
-        this.natural_width = Math.max(this.width, this.min_width);
-        this.natural_width_set = true;
+        // Use a hard actor width, not St's natural-width/natural-width-set:
+        // that pair only overrides the *natural* component, while the
+        // *minimum* is still computed dynamically per for_height (labels here
+        // wrap, so less height means a larger required width). If the popup
+        // is later reflowed at a smaller height - e.g. boxpointer shrinking it
+        // to fit the screen - the frozen natural-width can end up below the
+        // newly computed minimum, which Clutter treats as a fatal error and
+        // crashes the whole shell. A hard width pins both min and natural to
+        // the same value for every for_height, so that can't happen.
+        let [min_width, natural_width] = this.get_preferred_width(-1);
+        this.width = Math.max(natural_width, min_width);
     }
     unfreeze() {
-        this.natural_width = 0;
-        this.natural_width_set = false;
+        this.width = -1;
     }
     update(state) {
         this._label_item.setSummaryText(Math.round(state.percent) + ' %');


### PR DESCRIPTION
Add scrollbars to the drop-down panel to avoid overflow content outside the active screen.
<img width="3825" height="726" alt="Screenshot From 2026-07-31 15-15-00" src="https://github.com/user-attachments/assets/4768ce6d-2d31-4b8b-be9a-b04a19dcd71e" />

This fixes the issue https://github.com/elvetemedve/gnome-shell-extension-system-monitor/issues/106. 